### PR TITLE
Fixing non-binary mode read

### DIFF
--- a/mdm_vendor_sign.py
+++ b/mdm_vendor_sign.py
@@ -72,7 +72,7 @@ openssl rsa -in key.pem -out the_private_key.key
 	# Verify MDM vendor certificate
 	# openssl x509 -noout -in mdm.cer -inform DER
 	p('Verifying %s ... ' % cli_args['mdm'])
-	mdm_cert_file = open(cli_args['mdm']).read()
+	mdm_cert_file = open(cli_args['mdm'],'rb').read()  # Binary read
 	args = ['openssl', 'x509', '-noout', '-inform', 'DER' ]
 	command = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
 	output, error = command.communicate(input = mdm_cert_file)	


### PR DESCRIPTION
When I tried to use it in my environment (Python 2.7 running on Windows) it didn't work. I noted the mdm certificate was trying to be read with no parameters and binary mode must be specified in this case. The solution is to use binary mode when reading the file in this way. Note the 'rb'